### PR TITLE
Deal with other mods with bad data by just continueing the mixin

### DIFF
--- a/src/main/java/net/vassbo/vanillaemc/mixin/RecipeManagerMixin.java
+++ b/src/main/java/net/vassbo/vanillaemc/mixin/RecipeManagerMixin.java
@@ -55,8 +55,12 @@ public class RecipeManagerMixin {
 
             Iterator<Map.Entry<Identifier, JsonElement>> recipeIterator = map.entrySet().iterator();
             while (recipeIterator.hasNext()) {
-                Map.Entry<Identifier, JsonElement> entry = recipeIterator.next();
-                getRecipe(entry, registryOps);
+                try {
+                    Map.Entry<Identifier, JsonElement> entry = recipeIterator.next();
+                    getRecipe(entry, registryOps);
+                }catch (Exception e) {
+                    VanillaEMC.LOGGER.error("FOUND RECIPE WITH ISSUE" , e);
+                }
             }
 
             EMCValues.recipesLoaded(RECIPES, STONE_CUTTER_LIST);


### PR DESCRIPTION
ex: https://www.curseforge.com/minecraft/mc-mods/regs-more-foods

MapLike[{"funfact1":"This recipe has been disabled intentionally. This means it won't show up in-game.","funfact2":"/recipe also won't show it in the list. You really can't craft this at all!","heads_up":"Note from regfunkid: this recipe has been replaced by 'rabbit_stew' to keep things tidy!"}]